### PR TITLE
In email address placeholder, fix spelling from 'addrress' to 'address'

### DIFF
--- a/src/components/ContactForm/index.js
+++ b/src/components/ContactForm/index.js
@@ -69,7 +69,7 @@ const ContactForm = ({
                 <Field
                   name="email"
                   component={Input}
-                  placeholder="Email Addrress*"
+                  placeholder="Email Address*"
                   validate={composeValidators(required(), email())}
                 />
                 <Field

--- a/src/components/NewsLetter/index.js
+++ b/src/components/NewsLetter/index.js
@@ -85,7 +85,7 @@ const NewsLetter = ({
                               <Field
                                 name="email"
                                 component={Input}
-                                placeholder="Email Addrress*"
+                                placeholder="Email Address*"
                                 validate={composeValidators(
                                   required(),
                                   email()


### PR DESCRIPTION
Fix the incorrect spelling of "addrress" in the placeholder on the newsletter and the enquire form.

![Knotel_enquire_form_email_placeholder_misspelling](https://user-images.githubusercontent.com/19519844/235499295-22e8b441-492c-443f-9c16-973921cbe0f0.png)
